### PR TITLE
docs: add baseURL for accessing endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ npm test
 ```
 ### API Features/Endpoints
 The following are the API features and endpoints for the application which can be tested via [Postman](https://www.getpostman.com/) or any other API testing tool. 
+
+#### BASE_URL 
+All API endpoints can be accessed using baseURL
+
+- https://randomdial.herokuapp.com/api (remote)
+
+- http://localhost:3000/api (local)
+
 #### Generate Random 10-digits phone numbers
 `POST /phonenumbers` - Generates a single or multiple phone numbers (The amount to be generated should be specified in the request body).
 


### PR DESCRIPTION
#### Description
This PR updates the README to include **baseURL** for accessing API endpoints.

**Why?**
I tried getting the list of phone numbers from `https://randomdial.herokuapp.com/phonenumbers` and got an error. I thought it'd be nice to have the baseURL clearly stated in the README (I've seen the docs [here](https://documenter.getpostman.com/view/5131256/SVfKyWPA?version=latest)). 

#### Type of change

Please delete options that are not relevant

- [ ] New task (non-breaking change which helps improve the system)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New File change/update
- [x] Documentation
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation change

#### How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] End to end
- [ ] Unit Test

#### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing end-2-end tests pass locally with my changes

#### ISSUE
N/A
